### PR TITLE
Bugfix: Uninitialized entry count

### DIFF
--- a/include/DBoW2/TemplatedDatabase.h
+++ b/include/DBoW2/TemplatedDatabase.h
@@ -317,7 +317,7 @@ protected:
   DirectFile m_dfile;
   
   /// Number of valid entries in m_dfile
-  int m_nentries;
+  int m_nentries = 0;
   
 };
 


### PR DESCRIPTION
Stumbled upon this when trying to use `database.size() == 0` to prevent querying an empty database.