### PR TITLE
 Fix rare segfault

### DIFF
--- a/include/DBoW2/TemplatedVocabulary.h
+++ b/include/DBoW2/TemplatedVocabulary.h
@@ -692,6 +692,8 @@ void TemplatedVocabulary<TDescriptor,F>::HKmeansStep(NodeId parent_id,
           
           
           F::meanValue(cluster_descriptors, clusters[c]);
+          if(clusters[c].empty()) { clusters.erase(clusters.begin() + c); }//very rare
+
         }
         
       } // if(!first_time)


### PR DESCRIPTION
In k means, If a cluster is empty FORB::meanValue() will call relase() on the cv::Mat/TDescriptor parameter (i.e. clusters[c]). This will lead to a segfault in FORB::distance(). Therefore, if the cv::Mat is empty after meanValue(), it needs to be erased from the clusters vector before proceeding.