### PR TITLE
Add package.xml to cmake package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
     Enhanced hierarchical bag-of-word library for C++
   </description>
   <maintainer email="dorian3d@users.noreply.github.com">Dorian Gálvez-López</maintainer>
-  <license>BSD</license>
+  <license>BSD + notification</license>
 
   <buildtool_depend>cmake</buildtool_depend>
   

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>dbow2</name>
+  <version>1.1.0</version>
+  <description>
+    Enhanced hierarchical bag-of-word library for C++
+  </description>
+  <maintainer email="dorian3d@users.noreply.github.com">Dorian Gálvez-López</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  
+  <build_depend>libopencv-dev</build_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This PR simply adds a package.xml used for build tools like catkin or colcon, allowing for the essential build dependencies to be readily identified and when scheduling build order from dependency graphs.