### PR TITLE
fix load too slow bug

### DIFF
--- a/include/DBoW2/TemplatedVocabulary.h
+++ b/include/DBoW2/TemplatedVocabulary.h
@@ -1472,13 +1472,13 @@ void TemplatedVocabulary<TDescriptor,F>::load(const cv::FileStorage &fs,
 
   m_nodes.resize(fn.size() + 1); // +1 to include root
   m_nodes[0].id = 0;
-
-  for(unsigned int i = 0; i < fn.size(); ++i)
+  cv::FileNodeIterator end = fn.end();
+  for(cv::FileNodeIterator it = fn.begin(); it < end; ++it)
   {
-    NodeId nid = (int)fn[i]["nodeId"];
-    NodeId pid = (int)fn[i]["parentId"];
-    WordValue weight = (WordValue)fn[i]["weight"];
-    std::string d = (std::string)fn[i]["descriptor"];
+    NodeId nid = (int)(*it)["nodeId"];
+    NodeId pid = (int)(*it)["parentId"];
+    WordValue weight = (WordValue)(*it)["weight"];
+    std::string d = (std::string)(*it)["descriptor"];
     
     m_nodes[nid].id = nid;
     m_nodes[nid].parent = pid;
@@ -1492,11 +1492,12 @@ void TemplatedVocabulary<TDescriptor,F>::load(const cv::FileStorage &fs,
   fn = fvoc["words"];
   
   m_words.resize(fn.size());
+  end = fn.end();
 
-  for(unsigned int i = 0; i < fn.size(); ++i)
+  for(cv::FileNodeIterator it = fn.begin(); it < end; ++it)
   {
-    NodeId wid = (int)fn[i]["wordId"];
-    NodeId nid = (int)fn[i]["nodeId"];
+    NodeId wid = (int)(*it)["wordId"];
+    NodeId nid = (int)(*it)["nodeId"];
     
     m_nodes[nid].word_id = wid;
     m_words[wid] = &m_nodes[nid];


### PR DESCRIPTION
In OpenCV, cv::FileNode::operator[](int) and cv::FileNodeIterator::operator+=(int) has O(n) time complexity. So I changed fn[i] to iterator.The total time complexity is changed from O(n^2) to O(n)  
The OpenCV FileNode code can find [here](https://github.com/opencv/opencv/blob/4.x/modules/core/src/persistence.cpp).
In OpenCV4, the FileNode::operator[](int) calls FileNodeIterator::operator+=(int):
```cpp
FileNode FileNode::operator[](int i) const
{
    if(!fs)
        return FileNode();

    CV_Assert( isSeq() );

    int sz = (int)size();
    CV_Assert( 0 <= i && i < sz );

    FileNodeIterator it = begin();
    it += i; //Here OpenCV use operator+=

    return *it;
}
```
but the FileNodeIterator::operator+=(int) is not O(1) .It uses **FOR** to get i.
```cpp
FileNodeIterator& FileNodeIterator::operator += (int _ofs)
{
    CV_Assert( _ofs >= 0 );
    for( ; _ofs > 0; _ofs-- )
        this->operator ++();
    return *this;
}
```