### PR TITLE
Added FileNodeIterator for OpenCV 4.X to optimize vocabulary loading

### DIFF
--- a/include/DBoW2/TemplatedVocabulary.h
+++ b/include/DBoW2/TemplatedVocabulary.h
@@ -1473,12 +1473,14 @@ void TemplatedVocabulary<TDescriptor,F>::load(const cv::FileStorage &fs,
   m_nodes.resize(fn.size() + 1); // +1 to include root
   m_nodes[0].id = 0;
 
-  for(unsigned int i = 0; i < fn.size(); ++i)
+  unsigned int i = 0;
+  for(cv::FileNodeIterator it = fn.begin(); it != fn.end(); it++, i++)
   {
-    NodeId nid = (int)fn[i]["nodeId"];
-    NodeId pid = (int)fn[i]["parentId"];
-    WordValue weight = (WordValue)fn[i]["weight"];
-    std::string d = (std::string)fn[i]["descriptor"];
+    cv::FileNode fni =  *it;
+    NodeId nid = (int)fni["nodeId"];
+    NodeId pid = (int)fni["parentId"];
+    WordValue weight = (WordValue)fni["weight"];
+    std::string d = (std::string)fni["descriptor"];
     
     m_nodes[nid].id = nid;
     m_nodes[nid].parent = pid;
@@ -1493,10 +1495,13 @@ void TemplatedVocabulary<TDescriptor,F>::load(const cv::FileStorage &fs,
   
   m_words.resize(fn.size());
 
-  for(unsigned int i = 0; i < fn.size(); ++i)
+  i = 0;
+  for(cv::FileNodeIterator it = fn.begin(); it != fn.end(); it++, i++)
   {
-    NodeId wid = (int)fn[i]["wordId"];
-    NodeId nid = (int)fn[i]["nodeId"];
+    cv::FileNode fni =  *it;
+
+    NodeId wid = (int)fni["wordId"];
+    NodeId nid = (int)fni["nodeId"];
     
     m_nodes[nid].word_id = wid;
     m_words[wid] = &m_nodes[nid];


### PR DESCRIPTION
Since OpenCV 4.0.0, the core module has been completely reimplemented in C++.
see https://github.com/opencv/opencv/wiki/ChangeLog#version400

Iterating throught `FileNode` without iterator has become much more slower.
To compare, see `test_filenode` program in branch [yhabib29/DBoW2#dbg-opencv4](https://github.com/yhabib29/DBoW2/tree/dbg-opencv4).

Average time for each loop iteration in function `load` in `TemplatedVocabulary.h:1454`:
- Without iterator: **1,618,788 ns**.
- Using iterator:         **895 ns**.
Tested on vocabulary `ORBvoc.yml` [(download link)](http://www.dropbox.com/s/lyo0qgbdxn6eg6o/ORBvoc.zip?dl=1) with OpenCV 3.4.2 and 4.3.0 .